### PR TITLE
Allow to set current call as active

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ RNCallKeep.setup(options);
       
 ## Methods
 
-### setActive
+### setAvailable
 _This feature is available only on Android._
 
 Tell _ConnectionService_ that the device is ready to accept outgoing calls. 
@@ -80,7 +80,7 @@ If not the user will be stuck in the build UI screen without any actions.
 Eg: Call it with `false` when disconnected from the sip client, when your token expires ...
 
 ```js
-RNCallKeep.setActive(true);
+RNCallKeep.setAvailable(true);
 ```
 
 - `active`: boolean
@@ -143,6 +143,14 @@ RNCallKeep.endCall(uuid);
 
 - `uuid`: string
   - The `uuid` used for `startCall` or `displayIncomingCall`
+
+### setCurrentCallActive
+
+Mark the current call as active (eg: when the callee as answered).
+
+```js
+RNCallKeep.setCurrentCallActive();
+```
 
 
 ### setMutedCall
@@ -323,7 +331,7 @@ class RNCallKeepExample extends React.Component {
 
     try {
       RNCallKeep.setup(options);
-      RNCallKeep.setActive(true); // Only used for Android, see doc above.
+      RNCallKeep.setAvailable(true); // Only used for Android, see doc above.
     } catch (err) {
       console.error('initializeCallKeep error:', err.message);
     }

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -183,6 +183,16 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setCurrentCallActive() {
+        Connection conn = VoiceConnectionService.getConnection();
+        if (conn == null) {
+            return;
+        }
+
+        conn.setActive();
+    }
+
+    @ReactMethod
     public void openPhoneAccounts() {
         if (!isAvailable()) {
             return;

--- a/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
@@ -79,13 +79,13 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
         this.reactContext = reactContext;
 
-        VoiceConnectionService.setActive(false);
+        VoiceConnectionService.setAvailable(false);
 
-        if (isAvailable()) {
+        if (isConnectionServiceAvailable()) {
             this.registerPhoneAccount(this.getAppContext());
             voiceBroadcastReceiver = new VoiceBroadcastReceiver();
             registerReceiver();
-            VoiceConnectionService.setActive(false);
+            VoiceConnectionService.setAvailable(true);
         }
     }
 
@@ -105,7 +105,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void displayIncomingCall(String number, String callerName) {
-        if (!isAvailable() || !hasPhoneAccount()) {
+        if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
 
@@ -120,7 +120,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void startCall(String number, String callerName) {
-        if (!isAvailable() || !hasPhoneAccount()) {
+        if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
 
@@ -138,7 +138,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void endCall() {
-        if (!isAvailable() || !hasPhoneAccount()) {
+        if (!isConnectionServiceAvailable() || !hasPhoneAccount()) {
             return;
         }
 
@@ -154,7 +154,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void checkPhoneAccountPermission(Promise promise) {
-        if (!isAvailable()) {
+        if (!isConnectionServiceAvailable()) {
             promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "ConnectionService not available for this version of Android.");
             return;
         }
@@ -178,8 +178,8 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setActive(Boolean active) {
-        VoiceConnectionService.setActive(active);
+    public void setAvailable(Boolean active) {
+        VoiceConnectionService.setAvailable(active);
     }
 
     @ReactMethod
@@ -194,7 +194,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void openPhoneAccounts() {
-        if (!isAvailable()) {
+        if (!isConnectionServiceAvailable()) {
             return;
         }
 
@@ -214,13 +214,13 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public static Boolean isAvailable() {
+    public static Boolean isConnectionServiceAvailable() {
         // PhoneAccount is available since api level 23
         return Build.VERSION.SDK_INT >= 23;
     }
 
     private void registerPhoneAccount(Context appContext) {
-        if (!isAvailable()) {
+        if (!isConnectionServiceAvailable()) {
             return;
         }
 
@@ -267,7 +267,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule {
     }
 
     private static boolean hasPhoneAccount() {
-        if (!isAvailable()) {
+        if (!isConnectionServiceAvailable()) {
             return false;
         }
 

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -31,6 +31,7 @@ import android.telecom.ConnectionService;
 import android.telecom.DisconnectCause;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.TelecomManager;
+import android.util.Log;
 
 import static io.wazo.callkeep.RNCallKeepModule.ACTION_ANSWER_CALL;
 import static io.wazo.callkeep.RNCallKeepModule.ACTION_AUDIO_SESSION;
@@ -47,14 +48,14 @@ import static io.wazo.callkeep.RNCallKeepModule.EXTRA_CALLER_NAME;
 @TargetApi(Build.VERSION_CODES.M)
 public class VoiceConnectionService extends ConnectionService {
     private static Connection connection;
-    private static Boolean isActive = false;
+    private static Boolean isAvailable = false;
 
     public static Connection getConnection() {
         return connection;
     }
 
-    public static void setActive(Boolean value) {
-        isActive = value;
+    public static void setAvailable(Boolean value) {
+        isAvailable = value;
     }
 
 
@@ -87,7 +88,7 @@ public class VoiceConnectionService extends ConnectionService {
     }
 
     private Boolean canMakeOutgoingCall() {
-        return isActive;
+        return isAvailable;
     }
 
     private Connection createConnection(ConnectionRequest request) {

--- a/index.js
+++ b/index.js
@@ -13,13 +13,13 @@ class RNCallKeep {
   }
 
 
-  addEventListener(type, handler) {
+  addEventListener = (type, handler) => {
     const listener = listeners[type](handler);
 
     this._callkitEventHandlers.set(handler, listener);
-  }
+  };
 
-  removeEventListener(type, handler) {
+  removeEventListener = (type, handler) => {
     const listener = this._callkitEventHandlers.get(handler);
     if (!listener) {
       return;
@@ -27,9 +27,9 @@ class RNCallKeep {
 
     listener.remove();
     this._callkitEventHandlers.delete(handler);
-  }
+  };
 
-  setup(options) {
+  setup = (options) => {
     if (!isIOS) {
       return (async () => {
         return this._setupAndroid(options.android);
@@ -37,77 +37,80 @@ class RNCallKeep {
     }
 
     return this._setupIOS(options.ios);
-  }
+  };
 
-  displayIncomingCall(uuid, handle, localizedCallerName, handleType = 'number', hasVideo = false) {
+  displayIncomingCall = (uuid, handle, localizedCallerName, handleType = 'number', hasVideo = false) => {
     if (!isIOS) {
       RNCallKeepModule.displayIncomingCall(handle, localizedCallerName);
       return;
     }
 
     RNCallKeepModule.displayIncomingCall(uuid, handle, handleType, hasVideo, localizedCallerName);
-  }
+  };
 
-  startCall(uuid, handle, handleType = 'number', hasVideo = false, contactIdentifier) {
+  startCall = (uuid, handle, handleType = 'number', hasVideo = false, contactIdentifier) => {
     if (!isIOS) {
       RNCallKeepModule.startCall(handle, contactIdentifier);
       return;
     }
 
     RNCallKeepModule.startCall(uuid, handle, handleType, hasVideo, contactIdentifier);
-  }
+  };
 
-  reportConnectedOutgoingCallWithUUID(uuid) {
+  reportConnectedOutgoingCallWithUUID = (uuid) => {
     RNCallKeepModule.reportConnectedOutgoingCallWithUUID(uuid);
-  }
+  };
 
-  endCall(uuid) {
+  endCall = (uuid) => {
     isIOS ? RNCallKeepModule.endCall(uuid) : RNCallKeepModule.endCall();
-  }
+  };
 
-  endAllCalls() {
+  endAllCalls = () => {
     isIOS ? RNCallKeepModule.endAllCalls() : RNCallKeepModule.endCall();
-  }
+  };
 
-  supportConnectionService() {
-    return supportConnectionService;
-  }
+  supportConnectionService = () => supportConnectionService;
 
-  async hasPhoneAccount() {
-    return isIOS ? true : await RNCallKeepModule.hasPhoneAccount();
-  }
+  hasPhoneAccount = async () =>
+    isIOS ? true : await RNCallKeepModule.hasPhoneAccount();
 
-  setMutedCAll(uuid, muted) {
+  setMutedCAll = (uuid, muted) => {
      if (!isIOS) {
       // Can't mute on Android
       return;
     }
 
     RNCallKeepModule.setMutedCall(uuid, muted);
-  }
-
-  checkIfBusy() {
-    return Platform.OS === 'ios'
-      ? RNCallKeepModule.checkIfBusy()
-      : Promise.reject('RNCallKeep.checkIfBusy was called from unsupported OS');
   };
 
-  checkSpeaker() {
-    return Platform.OS === 'ios'
+  checkIfBusy = () =>
+    Platform.OS === 'ios'
+      ? RNCallKeepModule.checkIfBusy()
+      : Promise.reject('RNCallKeep.checkIfBusy was called from unsupported OS');
+
+  checkSpeaker = () =>
+    Platform.OS === 'ios'
       ? RNCallKeepModule.checkSpeaker()
       : Promise.reject('RNCallKeep.checkSpeaker was called from unsupported OS');
-  }
 
-  setActive = (state) => {
+  setAvailable = (state) => {
     if (isIOS) {
       return;
     }
 
     // Tell android that we are able to make outgoing calls
-    RNCallKeepModule.setActive(state);
-  }
+    RNCallKeepModule.setAvailable(state);
+  };
 
-  _setupIOS(options) {
+  setCurrentCallActive = () => {
+    if (isIOS) {
+      return;
+    }
+
+    RNCallKeepModule.setCurrentCallActive();
+  };
+
+  _setupIOS = (options) => {
     if (!options.appName) {
         throw new Error('RNCallKeep.setup: option "appName" is required');
     }
@@ -116,9 +119,9 @@ class RNCallKeep {
     }
 
     RNCallKeepModule.setup(options);
-  }
+  };
 
-  async _setupAndroid(options) {
+  _setupAndroid = async (options) => {
     const hasAccount = await RNCallKeepModule.checkPhoneAccountPermission();
     if (hasAccount) {
       return;
@@ -139,7 +142,7 @@ class RNCallKeep {
       ],
       { cancelable: true },
     );
-  }
+  };
 
   /*
   static holdCall(uuid, onHold) {

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class RNCallKeep {
   hasPhoneAccount = async () =>
     isIOS ? true : await RNCallKeepModule.hasPhoneAccount();
 
-  setMutedCAll = (uuid, muted) => {
+  setMutedCall = (uuid, muted) => {
      if (!isIOS) {
       // Can't mute on Android
       return;


### PR DESCRIPTION
When making a call directly from the native Phone app, we don't have a way to mark the call as active from now.
So I've added a `setCurrentCallActive ` method and renamed the `setActive` method to `setAvailable`.

cf: https://developer.android.com/reference/android/telecom/Connection.html#setActive()